### PR TITLE
Made the default to import relationship to false.

### DIFF
--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -54,7 +54,7 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
 
 - (BOOL) MR_shouldImportData:(id)relatedObjectData forRelationshipNamed:(NSString *)relationshipName;
 {
-    BOOL shouldImport = YES; // By default, we always import
+    BOOL shouldImport = NO; // By default, we should not import, unless 'self' defines an import for a relationship.
     SEL shouldImportSelector = NSSelectorFromString([NSString stringWithFormat:@"shouldImport%@:", [relationshipName MR_capitalizedFirstCharacterString]]);
     BOOL implementsShouldImport = [self respondsToSelector:shouldImportSelector];
 
@@ -67,6 +67,7 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
 
         [invocation getReturnValue:&shouldImport];
     }
+    
     return shouldImport;
 }
 


### PR DESCRIPTION
This would cause issues when the JSON does not include related data.
Should be NO if there is no definition for the shouldImport<Relation>.

The id of self will get passed, causing an KVC exception on a NSNumber, if importing is set to YES as the default state.
