### PR TITLE
Added guard for importing/updating a related object

### DIFF
--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -325,9 +325,12 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
             NSEntityDescription *entityDescription = [relationshipInfo destinationEntity];
             relatedObject = [entityDescription MR_createInstanceInContext:[strongSelf managedObjectContext]];
         }
+        
         //import or update
-        [relatedObject MR_importValuesForKeysWithObject:localObjectData];
-
+        if ([localObjectData isKindOfClass:[NSDictionary class]]) {
+        	[relatedObject MR_importValuesForKeysWithObject:localObjectData];
+	}
+	
         [strongSelf MR_setObject:relatedObject forRelationship:relationshipInfo];
 	};
 


### PR DESCRIPTION
We need to check that the incoming object is a dictionary. This may cause errors if the incoming data is malformed.
